### PR TITLE
Set API to partner endpoint.

### DIFF
--- a/modules/salesforce_soap/salesforce_soap.inc
+++ b/modules/salesforce_soap/salesforce_soap.inc
@@ -24,7 +24,7 @@ class SalesforceSoapPartner extends SforcePartnerClient {
    * @return string
    */
   private function endPoint() {
-    return $this->SalesforceApi->getInstanceURL() . "/services/Soap/c" . $this->SalesforceApi->rest_api_version['url'];
+    return $this->SalesforceApi->getInstanceURL() . "/services/Soap/u" . $this->SalesforceApi->rest_api_version['url'];
   }
 
 }


### PR DESCRIPTION
The endpoint was incorrectly set to the enterprise API. You wouldn't have noticed this because getDeleted() is the same for both the partner and enterprise APIs.
