### PR TITLE
Allow multiple mappings for the same entity/bundle/sf object/default record type

### DIFF
--- a/modules/salesforce_mapping/includes/salesforce_mapping.admin.inc
+++ b/modules/salesforce_mapping/includes/salesforce_mapping.admin.inc
@@ -529,8 +529,8 @@ function salesforce_mapping_form_validate($form, &$form_state) {
   $existing_mappings = salesforce_mapping_load_multiple($properties);
   foreach ($existing_mappings as $existing_mapping) {
     // Existing mapping, ensure not using any other unique combo. Less
-    // efficient than using in the query, but works with
-    // salesforce_mapping_load_multiple().
+    // efficient than adding a condition to the query, but works easily
+    // with salesforce_mapping_load_multiple().
     if (isset($mapping->name) && $mapping->name == $existing_mapping->name) {
       continue;
     }

--- a/modules/salesforce_mapping/includes/salesforce_mapping.admin.inc
+++ b/modules/salesforce_mapping/includes/salesforce_mapping.admin.inc
@@ -520,6 +520,27 @@ function salesforce_mapping_form_validate($form, &$form_state) {
     form_set_error('salesforce_record_type_default', t('Default record type must be one of the Allowed Record Types.'));
   }
 
+  $properties = array(
+    'salesforce_object_type' => $values['salesforce_object_type'],
+    'drupal_entity_type' => $values['drupal_entity_type'],
+    'drupal_bundle' => $values['drupal_bundle'],
+  );
+
+  $existing_mappings = salesforce_mapping_load_multiple($properties);
+  foreach ($existing_mappings as $existing_mapping) {
+    // Existing mapping, ensure not using any other unique combo. Less
+    // efficient than using in the query, but works with
+    // salesforce_mapping_load_multiple().
+    if (isset($mapping->name) && $mapping->name == $existing_mapping->name) {
+      continue;
+    }
+    foreach ($values['sync_triggers'] as $trigger => $trigger_enabled) {
+      if ($trigger_enabled && $existing_mapping->sync_triggers & $trigger) {
+        form_set_error('sync_triggers[' . $trigger . ']', t('This Drupal bundle has already been mapped to a Salesforce object using this trigger.'));
+      }
+    }
+  }
+
   // If Salesforce Object Create is selected, ensure that at least one mapping
   // is set to sync or SF to Drupal to prevent "empty" entities.
   if ($values['sync_triggers'][SALESFORCE_MAPPING_SYNC_SF_CREATE] && isset($values['salesforce_field_mappings'])) {

--- a/modules/salesforce_mapping/includes/salesforce_mapping.admin.inc
+++ b/modules/salesforce_mapping/includes/salesforce_mapping.admin.inc
@@ -328,7 +328,6 @@ function salesforce_mapping_form($form, &$form_state, SalesforceMapping $mapping
     '#description' => t('Select which actions on Drupal entities and Salesforce objects should trigger a synchronization. These settings are used by the salesforce_push and salesforce_pull modules respectively.'),
     '#default_value' => $trigger_defaults,
     '#options' => $trigger_options,
-    '#required' => TRUE,
   );
 
   $form['push_async'] = array(
@@ -519,23 +518,6 @@ function salesforce_mapping_form_validate($form, &$form_state) {
   }
   if (!in_array($values['salesforce_record_type_default'], $values['salesforce_record_types_allowed'])) {
     form_set_error('salesforce_record_type_default', t('Default record type must be one of the Allowed Record Types.'));
-  }
-  $efq = new EntityFieldQuery();
-  $efq
-    ->entityCondition('entity_type', 'salesforce_mapping')
-    ->propertyCondition('salesforce_object_type', $values['salesforce_object_type'])
-    ->propertyCondition('drupal_entity_type', $values['drupal_entity_type'])
-    ->propertyCondition('drupal_bundle', $values['drupal_bundle']);
-  $efq->count();
-
-  // Existing mapping, ensure not using any other unique combo.
-  if (isset($mapping->name)) {
-    $efq->propertyCondition('name', $mapping->name, '<>');
-  }
-
-  $count = $efq->execute();
-  if ($count > 0) {
-    form_set_error('drupal_bundle', t('This Drupal bundle has already been mapped to a Salesforce object.'));
   }
 
   // If Salesforce Object Create is selected, ensure that at least one mapping

--- a/modules/salesforce_mapping/salesforce_mapping.install
+++ b/modules/salesforce_mapping/salesforce_mapping.install
@@ -152,7 +152,6 @@ function salesforce_mapping_schema() {
         'drupal_entity_type',
         'drupal_bundle',
         'salesforce_object_type',
-        'salesforce_record_type_default',
       ),
     ),
   );
@@ -286,7 +285,6 @@ function salesforce_mapping_update_7302(&$sandbox) {
     'drupal_entity_type',
     'drupal_bundle',
     'salesforce_object_type',
-    'salesforce_record_type_default',
   ));
 
 }

--- a/modules/salesforce_mapping/salesforce_mapping.install
+++ b/modules/salesforce_mapping/salesforce_mapping.install
@@ -146,6 +146,8 @@ function salesforce_mapping_schema() {
     'primary key' => array('salesforce_mapping_id'),
     'unique keys' => array(
       'name' => array('name'),
+    ),
+    'indexes' => array(
       'name_sf_type_drupal_type' => array(
         'drupal_entity_type',
         'drupal_bundle',
@@ -269,4 +271,22 @@ function salesforce_mapping_update_7301(&$sandbox) {
     );
     $mapping->save();
   }
+}
+
+/**
+ * Change index on Salesforce mapping to be non-unique.
+ */
+function salesforce_mapping_update_7302(&$sandbox) {
+
+  // Remove unique key.
+  db_drop_unique_key('salesforce_mapping', 'name_sf_type_drupal_type');
+
+  // Add non-unique key back.
+  db_add_index('salesforce_mapping', 'name_sf_type_drupal_type', array(
+    'drupal_entity_type',
+    'drupal_bundle',
+    'salesforce_object_type',
+    'salesforce_record_type_default',
+  ));
+
 }


### PR DESCRIPTION
@caxy4 and I ran into a whole bunch of problems with overriding stock GivingForum mappings for Donors Forum. This solution removes the unique key on entity/bundle/sf object/record type and also makes the sync trigger property not required.

The result is that you can have mappings where no triggers selected that are effectively inactive mappings. This will allow us to clone the default GF mappings and create our own for the same combo of entities/objects that can then be exported to features (without the mess that is features_override).

This also allows, through the UI, being able to create different mappings for different triggers. One use case might be CampaignMember records - Contact and Campaign fields in SF only allow writing on create, not update. A create mapping could be created that includes these two fields while an update mapping would not include them. We currently handle this in hook_salesforce_push_params_alter().

An active flag was also discussed, and would work for us, but would require more extensive code updates.

@levelos and @bleeDev - thoughts?
