### PR TITLE
7.1-3.2 Proposed updates

### DIFF
--- a/includes/salesforce.inc
+++ b/includes/salesforce.inc
@@ -705,7 +705,10 @@ class Salesforce {
 
   /**
    * Return a list of SFIDs for the given object, which have been created or
-   * updated in the given timeframe. 
+   * updated in the given timeframe.
+   *
+   * @param string $name
+   *   Object type name, E.g., Contact, Account.
    *
    * @param int $start
    *   unix timestamp for older timeframe for updates. 

--- a/includes/salesforce.inc
+++ b/includes/salesforce.inc
@@ -672,6 +672,22 @@ class Salesforce {
   }
 
   /**
+   * Retrieves the list of individual objects that have been deleted within the
+   * given timespan for a specified object type.
+   *
+   * @param string $type
+   *   Object type name, E.g., Contact, Account.
+   * @param string $startDate
+   *   Start date to check for deleted objects (in ISO 8601 format).
+   * @param string $endDate
+   *   End date to check for deleted objects (in ISO 8601 format).
+   * @return GetDeletedResult
+   */
+  public function getDeleted($type, $startDate, $endDate) {
+    return $this->apiCall("sobjects/{$type}/deleted/?start={$startDate}&end={$endDate}");
+  }
+
+  /**
    * Return a list of available resources for the configured API version.
    *
    * @return array

--- a/includes/salesforce.inc
+++ b/includes/salesforce.inc
@@ -284,7 +284,11 @@ class Salesforce {
    * Get refresh token.
    */
   protected function getRefreshToken() {
-    return variable_get('salesforce_refresh_token', '');
+    $salesforce_refresh_token = variable_get('salesforce_refresh_token', '');
+    if (module_exists('encrypt')) {
+      $salesforce_refresh_token = decrypt($salesforce_refresh_token);
+    }
+    return $salesforce_refresh_token;
   }
 
   /**
@@ -294,6 +298,9 @@ class Salesforce {
    *   Refresh token from Salesforce.
    */
   protected function setRefreshToken($token) {
+    if (module_exists('encrypt')) {
+      $token = encrypt($token);
+    }
     variable_set('salesforce_refresh_token', $token);
   }
 

--- a/includes/salesforce.inc
+++ b/includes/salesforce.inc
@@ -727,3 +727,6 @@ class Salesforce {
 
 class SalesforceException extends Exception {
 }
+
+class SalesforcePullException extends SalesforceException {
+}

--- a/includes/salesforce.inc
+++ b/includes/salesforce.inc
@@ -25,9 +25,9 @@ class Salesforce {
     $this->login_url = variable_get('salesforce_endpoint', 'https://login.salesforce.com');
 
     $this->rest_api_version = variable_get('salesforce_api_version', array(
-      "label" => "Spring '13",
-      "url" => "/services/data/v27.0/",
-      "version" => "27.0",
+      "label" => "Winter '14",
+      "url" => "/services/data/v29.0/",
+      "version" => "29.0",
     ));
   }
 
@@ -655,6 +655,43 @@ class Salesforce {
       $items[$key] = $path;
     }
     return $items;
+  }
+
+  /**
+   * Return a list of SFIDs for the given object, which have been created or
+   * updated in the given timeframe. 
+   *
+   * @param int $start
+   *   unix timestamp for older timeframe for updates. 
+   *   Defaults to "-29 days" if empty.
+   *
+   * @param int $end
+   *   unix timestamp for end of timeframe for updates. 
+   *   Defaults to now if empty
+   *
+   * @return array
+   *   return array has 2 indexes:
+   *     "ids": a list of SFIDs of those records which have been created or
+   *       updated in the given timeframe.
+   *     "latestDateCovered": ISO 8601 format timestamp (UTC) of the last date
+   *       covered in the request.
+   *
+   * @see https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_getupdated.htm
+   *
+   * @addtogroup salesforce_apicalls
+   */
+  public function getUpdated($name, $start = null, $end = null) {
+    if (empty($start)) {
+      $start = strtotime('-29 days');
+    }
+    $start = urlencode(gmdate(DATE_ATOM, $start));
+  
+    if (empty($end)) {
+      $end = time();
+    }
+    $end = urlencode(gmdate(DATE_ATOM, $end));
+  
+    return $this->apiCall("sobjects/{$name}/updated/?start=$start&end=$end");
   }
 }
 

--- a/includes/salesforce.inc
+++ b/includes/salesforce.inc
@@ -203,6 +203,13 @@ class Salesforce {
    *   Salesforce response object.
    */
   protected function httpRequest($url, $data, $headers = array(), $method = 'GET') {
+
+    // If method is GET, data should not be sent otherwise drupal_http_request()
+    // will set Content-Length header which confuses some proxies like Squid.
+    if ($method === 'GET') {
+      $data = NULL;
+    }
+
     // Build the request, including path and headers. Internal use.
     $options = array(
       'method' => $method,

--- a/includes/salesforce.inc
+++ b/includes/salesforce.inc
@@ -59,6 +59,29 @@ class Salesforce {
   }
 
   /**
+   * Given a Salesforce ID, return the corresponding SObject name. (Based on
+   *  keyPrefix from object definition, @see
+   *  https://developer.salesforce.com/forums/?id=906F0000000901ZIAQ )
+   *
+   * @param string $sfid
+   *   15- or 18-character Salesforce ID
+   * @return string
+   *   sObject name, e.g. "Account", "Contact", "my__Custom_Object__c" or FALSE
+   *   if no match could be found.
+   * @throws SalesforceException
+   */
+  public function getSobjectType($sfid) {
+    $objects = $this->objects(array('keyPrefix' => substr($sfid, 0, 3)));
+    if (count($objects) == 1) {
+      // keyPrefix is unique across objects. If there is exactly one return value from objects(), then we have a match.
+      $object = reset($objects);
+      return $object['name'];
+    }
+    // Otherwise, we did not find a match.
+    return FALSE;
+  }
+
+  /**
    * Determine if this SF instance is fully configured.
    *
    * @TODO: Consider making a test API call.
@@ -445,7 +468,7 @@ class Salesforce {
     if (!empty($conditions)) {
       foreach ($result['sobjects'] as $key => $object) {
         foreach ($conditions as $condition => $value) {
-          if (!$object[$condition] == $value) {
+          if ($object[$condition] != $value) {
             unset($result['sobjects'][$key]);
           }
         }

--- a/includes/salesforce.inc
+++ b/includes/salesforce.inc
@@ -149,7 +149,7 @@ class Salesforce {
       $data = $data[0];
     }
 
-    if (isset($data['error'])) {
+    if (is_array($data) && isset($data['error'])) {
       throw new SalesforceException($data['error_description'], $data['error']);
     }
 

--- a/includes/salesforce.select_query.inc
+++ b/includes/salesforce.select_query.inc
@@ -91,6 +91,9 @@ class SalesforceSelectQuery {
     if ($this->offset) {
       $query .= "+OFFSET+" . (int) $this->offset;
     }
+    
+    // Replaces spaces with + signs for custom filters.
+    $query = str_replace(" ", "+", $query);
 
     return $query;
   }

--- a/modules/salesforce_mapping/includes/salesforce_mapping.admin.inc
+++ b/modules/salesforce_mapping/includes/salesforce_mapping.admin.inc
@@ -690,7 +690,8 @@ function salesforce_mapping_form_submit($form, &$form_state) {
         if (isset($field_map['salesforce_multiple_fields']) && $field_map['salesforce_multiple_fields']) {
           $sf_field = array();
           foreach ($mapping['salesforce_field'] as $field) {
-            $sf_field[] = reset(array_filter($sf_fields, salesforce_field_filter($field)));
+            $filtered = array_filter($sf_fields, salesforce_field_filter($field));
+            $sf_field[] = reset($filtered);
           }
         }
         else {

--- a/modules/salesforce_mapping/includes/salesforce_mapping.admin.inc
+++ b/modules/salesforce_mapping/includes/salesforce_mapping.admin.inc
@@ -574,7 +574,7 @@ function salesforce_mapping_form_validate($form, &$form_state) {
   if (strlen($values['name']) > SALESFORCE_MAPPING_NAME_LENGTH) {
     form_set_error('name', t('Name must not exceed @max characters.', array('@max' => SALESFORCE_MAPPING_NAME_LENGTH)));
   }
-  if (!in_array($values['salesforce_record_type_default'], $values['salesforce_record_types_allowed'])) {
+  if (isset($values['salesforce_record_type_default']) && !in_array($values['salesforce_record_type_default'], $values['salesforce_record_types_allowed'])) {
     form_set_error('salesforce_record_type_default', t('Default record type must be one of the Allowed Record Types.'));
   }
 

--- a/modules/salesforce_mapping/includes/salesforce_mapping.admin.inc
+++ b/modules/salesforce_mapping/includes/salesforce_mapping.admin.inc
@@ -1195,9 +1195,15 @@ function _salesforce_mapping_get_direction_options() {
   if (module_exists('salesforce_push')) {
     $options += array(
       SALESFORCE_MAPPING_DIRECTION_DRUPAL_SF => t('Drupal to SF'),
+    );
+  }
+
+  if (module_exists('salesforce_pull') && module_exists('salesforce_push')) {
+    $options += array(
       SALESFORCE_MAPPING_DIRECTION_SYNC => t('Sync'),
     );
   }
+
   return $options;
 }
 

--- a/modules/salesforce_mapping/includes/salesforce_mapping.admin.inc
+++ b/modules/salesforce_mapping/includes/salesforce_mapping.admin.inc
@@ -276,11 +276,7 @@ function salesforce_mapping_form($form, &$form_state, SalesforceMapping $mapping
       $row['direction'] = array(
         '#id' => 'edit-direction-' . $delta,
         '#type' => 'radios',
-        '#options' => array(
-          SALESFORCE_MAPPING_DIRECTION_DRUPAL_SF => t('Drupal to SF'),
-          SALESFORCE_MAPPING_DIRECTION_SF_DRUPAL => t('SF to Drupal'),
-          SALESFORCE_MAPPING_DIRECTION_SYNC => t('Sync'),
-        ),
+        '#options' => _salesforce_mapping_get_direction_options(),
         '#required' => TRUE,
         '#default_value' => _salesforce_mapping_get_default_value('direction', $form_state, $delta),
       );
@@ -903,7 +899,8 @@ function _salesforce_mapping_get_default_value($field, &$form_state, $delta = NU
 
       case 'direction':
         // Set default for direction, which cannot be NULL like the others.
-        $value = SALESFORCE_MAPPING_DIRECTION_SYNC;
+        $keys = array_keys(_salesforce_mapping_get_direction_options());
+        $value = end($keys);
         // No break for this case, should carry onto the default case.
       default:
         if (isset($form_state['input']['salesforce_field_mappings'][$delta][$field])) {
@@ -1015,10 +1012,16 @@ function _salesforce_mapping_get_salesforce_object_type_options(&$form_state, $i
   else {
     $sfapi = salesforce_get_api();
     // Note that we're filtering SF object types to a reasonable subset.
-    $sfobjects = $sfapi->objects(array(
-      'updateable' => TRUE,
+    $sf_object_filter = array(
       'triggerable' => TRUE,
-    ));
+    );
+
+    //TODO: Handle this somewhere else to validate we can push to this object.
+    // if (module_exists('salesforce_push')) {
+    //   $sf_object_filter['updateable'] = TRUE;
+    // }
+    
+    $sfobjects = $sfapi->objects($sf_object_filter);
     $form_state['sfm_storage']['salesforce_object_type'] = $sfobjects;
   }
 
@@ -1152,18 +1155,49 @@ function _salesforce_mapping_get_drupal_type_options($include_select = TRUE) {
  * Return form options for available sync triggers.
  *
  * @return array
- *   Array of sync trigger options keyed by their machine name with their lable
+ *   Array of sync trigger options keyed by their machine name with their label
  *   as the value.
  */
 function _salesforce_mapping_get_sync_trigger_options() {
-  return array(
-    SALESFORCE_MAPPING_SYNC_DRUPAL_CREATE => t('Drupal entity create'),
-    SALESFORCE_MAPPING_SYNC_DRUPAL_UPDATE => t('Drupal entity update'),
-    SALESFORCE_MAPPING_SYNC_DRUPAL_DELETE => t('Drupal entity delete'),
-    SALESFORCE_MAPPING_SYNC_SF_CREATE => t('Salesforce object create'),
-    SALESFORCE_MAPPING_SYNC_SF_UPDATE => t('Salesforce object update'),
-    SALESFORCE_MAPPING_SYNC_SF_DELETE => t('Salesforce object delete'),
-  );
+  $options = array();
+  if (module_exists('salesforce_push')) {
+    $options += array(
+      SALESFORCE_MAPPING_SYNC_DRUPAL_CREATE => t('Drupal entity create'),
+      SALESFORCE_MAPPING_SYNC_DRUPAL_UPDATE => t('Drupal entity update'),
+      SALESFORCE_MAPPING_SYNC_DRUPAL_DELETE => t('Drupal entity delete'),
+    );
+  }
+  if (module_exists('salesforce_pull')) {
+    $options += array(
+      SALESFORCE_MAPPING_SYNC_SF_CREATE => t('Salesforce object create'),
+      SALESFORCE_MAPPING_SYNC_SF_UPDATE => t('Salesforce object update'),
+      SALESFORCE_MAPPING_SYNC_SF_DELETE => t('Salesforce object delete'),
+    );
+  }
+  return $options;
+}
+
+/**
+ * Return form options for available direction options.
+ *
+ * @return array
+ *   Array of direction options keyed by their machine name with their label
+ *   as the value.
+ */
+function _salesforce_mapping_get_direction_options() {
+  $options = array();
+  if (module_exists('salesforce_pull')) {
+    $options += array(
+      SALESFORCE_MAPPING_DIRECTION_SF_DRUPAL => t('SF to Drupal'),
+    );
+  }
+  if (module_exists('salesforce_push')) {
+    $options += array(
+      SALESFORCE_MAPPING_DIRECTION_DRUPAL_SF => t('Drupal to SF'),
+      SALESFORCE_MAPPING_DIRECTION_SYNC => t('Sync'),
+    );
+  }
+  return $options;
 }
 
 /**
@@ -1213,6 +1247,6 @@ function _salesforce_mapping_get_empty_field_map_row() {
     'drupal_field' => '',
     'salesforce_field' => '',
     'key' => '',
-    'direction' => SALESFORCE_MAPPING_DIRECTION_SYNC,
+    'direction' => end(array_keys(_salesforce_mapping_get_direction_options())),
   );
 }

--- a/modules/salesforce_mapping/includes/salesforce_mapping.fieldmap_type.inc
+++ b/modules/salesforce_mapping/includes/salesforce_mapping.fieldmap_type.inc
@@ -379,6 +379,18 @@ function salesforce_mapping_property_fieldmap_pull_value($entity_wrapper, $sf_ob
     case 'text':
       $value = (string) $value;
       break;
+
+    case 'uri':
+      if (!empty($value) &&!valid_url($value, TRUE)) {
+        $parsed_value = parse_url($value);
+        // Salesforce tacks on an http:// to the front of URLs as necessary, but
+        // it still passes the naked version to the API, so we correct it.
+        if (!isset($parsed_value['scheme'])) {
+          $value = 'http://' . $value;
+        }
+      }
+
+      break;
   }
 
   return $value;

--- a/modules/salesforce_mapping/includes/salesforce_mapping.fieldmap_type.inc
+++ b/modules/salesforce_mapping/includes/salesforce_mapping.fieldmap_type.inc
@@ -364,6 +364,7 @@ function salesforce_mapping_property_fieldmap_pull_value($entity_wrapper, $sf_ob
     $value = explode(SALESFORCE_MAPPING_ARRAY_DELIMITER, $value);
   }
 
+  // Marshalling for data types that are formatted differently on Salesforce.
   switch ($entity_wrapper->type()) {
     case 'date':
       if (isset($value) && ($field_map['salesforce_field']['type'] == 'date' || $field_map['salesforce_field']['type'] == 'datetime')) {

--- a/modules/salesforce_mapping/salesforce_mapping.install
+++ b/modules/salesforce_mapping/salesforce_mapping.install
@@ -1,6 +1,29 @@
 <?php
 
 /**
+ * Implements hook_requirements().
+ */
+function salesforce_mapping_requirements($phase) {
+  $requirements = array();
+  $t = get_t();
+  switch($phase) {
+    case 'install':
+      drupal_set_message(t('At least one sync method (Push or Pull) must be <a href="/admin/modules">enabled</a> to configure Salesforce Mappings.'), 'status', FALSE);
+      break;
+    case 'runtime':
+      if (!module_exists('salesforce_pull') && !module_exists('salesforce_push')) {
+        $requirements['salesforce_mapping'] = array(
+          'title' => $t('Salesforce Mapping'),
+          'description' => $t('<a href="/admin/modules">Enable</a> at least one sync method (Push or Pull) to configure Salesforce Mappings.'),
+          'severity' => REQUIREMENT_ERROR,
+        );
+      }
+      break;
+  }
+  return $requirements;
+}
+
+/**
  * @file
  * Install and uninstall instructions for salesforce_mapping.
  */

--- a/modules/salesforce_mapping/salesforce_mapping.module
+++ b/modules/salesforce_mapping/salesforce_mapping.module
@@ -50,11 +50,24 @@ define('SALESFORCE_MAPPING_STATUS_ERROR', 0);
  * Access callback for managing Salesforce mappings.
  */
 function salesforce_mappings_access() {
+  if (!module_exists('salesforce_pull') && !module_exists('salesforce_push')) {
+    return FALSE;
+  }
+
   if (user_access('administer salesforce mapping')) {
     $sfapi = salesforce_get_api();
     return $sfapi->isAuthorized();
   }
   return FALSE;
+}
+
+/**
+ * Implements hook_page_alter().
+ */
+function salesforce_mapping_page_alter(&$page) {
+  if (current_path() == 'admin/structure/salesforce' && !module_exists('salesforce_pull') && !module_exists('salesforce_push')) {
+    drupal_set_message(t('At least one sync method (Push or Pull) must be <a href="/admin/modules">enabled</a> to configure Salesforce Mappings.'), 'error', FALSE);
+  }
 }
 
 /**

--- a/modules/salesforce_mapping/salesforce_mapping.module
+++ b/modules/salesforce_mapping/salesforce_mapping.module
@@ -257,6 +257,12 @@ function salesforce_mapping_salesforce_mapping_entity_uris_alter(&$entity_uris) 
   $entity_uris['user'] = array(
     'path' => 'user/',
   );
+  $entity_uris['taxonomy_term'] = array(
+    'path' => 'taxonomy/term/',
+  );
+  $entity_uris['relation'] = array(
+    'path' => 'relation/',
+  );
 }
 
 /**

--- a/modules/salesforce_mapping/salesforce_mapping.module
+++ b/modules/salesforce_mapping/salesforce_mapping.module
@@ -245,7 +245,7 @@ function salesforce_mapping_menu() {
 }
 
 /**
- * Implements hook_salesforce_mapping_entity_uris().
+ * Implements hook_salesforce_mapping_entity_uris_alter().
  *
  * Node and User, like most entities in core, don't respond well to entity_uri()
  * calls on unsaved entity stubs, which is what we need for our menu items.

--- a/modules/salesforce_mapping/tests/salesforce_mapping.entities.test
+++ b/modules/salesforce_mapping/tests/salesforce_mapping.entities.test
@@ -212,7 +212,7 @@ class SalesforceMappingEntitiesTestCase extends SalesforceMappingTestCase {
 
     // Save the entity again and see it be updated.
     $result = entity_save('salesforce_mapping_object', $test_map);
-    $this->assertEqual(SAVED_UPDATED, $result, 'Re-saved entity saved as updated.');
+    $this->assertEqual(SAVED_UPDATED, $test_map->revision_id, 'Re-saved entity saved as updated.');
 
     // Delete the entity from the database.
     entity_delete('salesforce_mapping_object', $test_map_db->salesforce_mapping_object_id);

--- a/modules/salesforce_mapping/tests/salesforce_mapping.entities.test
+++ b/modules/salesforce_mapping/tests/salesforce_mapping.entities.test
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Simple tests for salesforce_mapping
+ * Simple tests for salesforce_mapping.
  */
 
 module_load_include('test', 'salesforce_mapping', 'tests/salesforce_mapping');
@@ -37,6 +37,7 @@ class SalesforceMappingEntitiesTestCase extends SalesforceMappingTestCase {
       'sync_triggers' => 0x0002,
       'salesforce_object_type' => 'bar',
       'salesforce_record_type' => 'baz',
+      'salesforce_record_types_allowed' => array("baz" => "baz", "bogus" => "0"),
       'drupal_entity_type' => 'node',
       'drupal_bundle' => 'story',
       'field_mappings' => array(
@@ -162,6 +163,34 @@ class SalesforceMappingEntitiesTestCase extends SalesforceMappingTestCase {
   }
 
   /**
+   * Tests API for interacting with salesforce_mapping.
+   */
+  public function testObjectTypeMapSalesforceMappingLoadMultipleInvalidType() {
+    // Create an invalid mapping entity to work with.
+    $this->example_map_invalid = $this->example_map;
+    $this->example_map_invalid['name'] = 'bogus_record';
+    $this->example_map_invalid['salesforce_record_type'] = 'bogus';
+    $example_map_invalid = entity_create('salesforce_mapping', $this->example_map_invalid);
+    entity_save('salesforce_mapping', $example_map_invalid);
+
+    // salesforce_mapping_load() to prove mapping saved.
+    $result = salesforce_mapping_load($example_map_invalid->name);
+    $this->assertTrue(is_object($result), 'Loading maps stating a specific name returned an object.');
+    $this->assertEqual($example_map_invalid->label, $result->label, 'Loading maps stating a specific name returned the requested map.');
+
+    // salesforce_mapping_load_multiple() shows no parameters loads the mapping.
+    $result = salesforce_mapping_load_multiple();
+    $this->assertTrue(is_array($result), 'Loading maps without stating a specific property returned an array.');
+    $this->assertEqual(1, count($result), 'Loading maps without stating a specific property returned 1 maps.');
+
+    // salesforce_mapping_load_multiple() excludes invalid types.
+    $result = salesforce_mapping_load_multiple(array('salesforce_record_type' => 'bogus'));
+    $this->assertTrue(is_array($result), 'Loading maps stating the drupal_bundle returned an array.');
+    $this->assertEqual(0, count($result), 'Loading maps stating the drupal_bundle property returned 0 map.');
+    $map = reset($result);
+  }
+
+  /**
    * Test the salesforce_mapping_object entity.
    */
   public function testRecordMapEntity() {
@@ -227,4 +256,5 @@ class SalesforceMappingEntitiesTestCase extends SalesforceMappingTestCase {
     $result = salesforce_mapping_object_load_by_sfid('nothing');
     $this->assertFalse($result, 'Loading map by salesforce_id for something that does not exist returns FALSE.');
   }
+
 }

--- a/modules/salesforce_mapping/tests/salesforce_mapping.entities.test
+++ b/modules/salesforce_mapping/tests/salesforce_mapping.entities.test
@@ -163,7 +163,7 @@ class SalesforceMappingEntitiesTestCase extends SalesforceMappingTestCase {
   }
 
   /**
-   * Tests API for interacting with salesforce_mapping.
+   * Tests API for salesforce_mapping_load_multiple with limited type.
    */
   public function testObjectTypeMapSalesforceMappingLoadMultipleInvalidType() {
     // Create an invalid mapping entity to work with.

--- a/modules/salesforce_mapping/tests/salesforce_mapping.test
+++ b/modules/salesforce_mapping/tests/salesforce_mapping.test
@@ -152,6 +152,11 @@ class SalesforceMappingTestCase extends SalesforceTestCase {
       }
     }
 
+    // Submit form unsuccessfully.
+    $this->drupalPost(NULL, $edit, 'Save mapping');
+    $this->assertText('Salesforce field Email is not configured as an external id.', 'Invalid key not allowed');
+    unset($edit['key']);
+
     // Submit form.
     $this->drupalPost(NULL, $edit, 'Save mapping');
     $this->assertText('Salesforce field mapping saved.', 'Form posted as expected.');

--- a/modules/salesforce_pull/salesforce_pull.module
+++ b/modules/salesforce_pull/salesforce_pull.module
@@ -609,11 +609,25 @@ function salesforce_pull_map_fields($field_maps, &$entity_wrapper, $sf_object) {
       if (isset($value)) {
         // @TODO: might wrongly assumes an individual value wouldn't be an
         // array.
-        if ($parent instanceof EntityListWrapper && !is_array($value)) {
-          $parent->offsetSet(0, $value);
+        try {
+          if ($parent instanceof EntityListWrapper && !is_array($value)) {
+            $parent->offsetSet(0, $value);
+          }
+          else {
+            $parent->set($value);
+          }
         }
-        else {
-          $parent->set($value);
+        catch (Exception $e) {
+          $message = t('Exception during pull for @sfobj.@sffield @sfid to @dobj.@dprop @did with value @v: @e', array(
+            '@sfobj' => $sf_object['attributes']['type'],
+            '@sffield' =>  $field_map['salesforce_field']['name'],
+            '@sfid' => $sf_object['Id'],
+            '@dobj' => $entity_wrapper->type(),
+            '@dprop' => $field_map['drupal_field']['fieldmap_value'],
+            '@did' => $entity_wrapper->getIdentifier(),
+            '@v' => $value,
+            '@e' => $e->getMessage()));
+          throw new Exception($message, $e->getCode(), $e);
         }
       }
     }

--- a/modules/salesforce_pull/salesforce_pull.module
+++ b/modules/salesforce_pull/salesforce_pull.module
@@ -485,77 +485,92 @@ function salesforce_pull_process_records($sf_object) {
  * Process deleted records from salesforce.
  */
 function salesforce_pull_process_deleted_records() {
-  // Only the SOAP API supports getting deleted records.
-  if (!module_exists('salesforce_soap')) {
-    salesforce_set_message('Enable Salesforce SOAP to process deleted records');
-    return;
-  }
+  // Calculate which client to use. We default to the REST client but also
+  // support SOAP if enabled. Note that deletions can only be queried via REST
+  // with an API version >= 29.0.
   $sfapi = salesforce_get_api();
-  $soap = new SalesforceSoapPartner($sfapi);
+  $client = $sfapi;
+  if (class_exists('SalesforceSoapPartner')) {
+    $client = new SalesforceSoapPartner($sfapi);
+  }
 
   // Load all unique SF record types that we have mappings for.
   foreach (array_reverse(salesforce_mapping_get_mapped_objects()) as $type) {
     $last_delete_sync = variable_get('salesforce_pull_delete_last_' . $type, REQUEST_TIME);
+    variable_set('salesforce_pull_delete_last_' . $type, REQUEST_TIME);
+
     $now = time();
 
-    // SOAP getDeleted() restraint: startDate must be at least one minute
-    // greater than endDate.
+    // getDeleted() constraint: startDate cannot be more than 30 days ago
+    // (using an incompatible data may lead to exceptions).
+    $last_delete_sync = $last_delete_sync > REQUEST_TIME - 2505600 ? $last_delete_sync : REQUEST_TIME - 2505600;
+
+    // getDeleted() constraint: startDate must be at least one minute greater
+    // than endDate.
     $now = $now > $last_delete_sync + 60 ? $now : $now + 60;
     $last_delete_sync_sf = gmdate('Y-m-d\TH:i:s\Z', $last_delete_sync);
     $now_sf = gmdate('Y-m-d\TH:i:s\Z', $now);
-    $deleted = $soap->getDeleted($type, $last_delete_sync_sf, $now_sf);
-    if (!empty($deleted->deletedRecords)) {
-      foreach ($deleted->deletedRecords as $record) {
-        $mapping_object = salesforce_mapping_object_load_by_sfid($record->id);
-        if ($mapping_object) {
-          // Load and wrap the Drupal entity linked to the SF object.
-          $entity = entity_load_single($mapping_object->entity_type, $mapping_object->entity_id);
-          // Check if entity exists before processing delete.
-          if ($entity) {
-            $entity_wrapper = entity_metadata_wrapper($mapping_object->entity_type, $entity);
 
-            // Load the mapping that manages these mapped objects.
-            $sf_mapping = reset(salesforce_mapping_load_multiple(
-              array(
-                'salesforce_object_type' => $type,
-                'drupal_entity_type' => $entity_wrapper->type(),
-                'drupal_bundle' => $entity_wrapper->getBundle(),
-              )
-            ));
+    // SOAP getDeleted() returns an object while the REST getDeleted() returns
+    // an array, so cast all checked values to an object to avoid additional
+    // conditional logic.
+    $deleted = (object) $client->getDeleted($type, $last_delete_sync_sf, $now_sf);
+    if (empty($deleted->deletedRecords)) {
+      continue;
+    }
+    foreach ($deleted->deletedRecords as $record) {
+      $record = (object) $record;
+      $mapping_object = salesforce_mapping_object_load_by_sfid($record->id);
+      if (!$mapping_object) {
+        continue;
+      }
 
-            // Only delete the mapped Drupal entity if the
-            // SALESFORCE_MAPPING_SYNC_SF_DELETE flag is set.
-            if (!empty($sf_mapping) && ($sf_mapping->sync_triggers & SALESFORCE_MAPPING_SYNC_SF_DELETE)) {
-              // Prevent processing by salesforce_push. We hate circular logic.
-              $entity->salesforce_pull = TRUE;
+      // Load and wrap the Drupal entity linked to the SF object.
+      $entity = entity_load_single($mapping_object->entity_type, $mapping_object->entity_id);
 
-              // Delete the mapped Drupal entity. Catch any exceptions as
-              // we want to ensure the mapping object is deleted even in
-              // case of an error.
-              try {
-                $entity_wrapper->delete();
-              } catch (Exception $e) {
-                watchdog_exception('salesforce_pull', $e);
-              }
+      // Check if entity exists before processing delete.
+      if ($entity) {
+        $entity_wrapper = entity_metadata_wrapper($mapping_object->entity_type, $entity);
 
-              watchdog('Salesforce Pull',
-                'Deleted entity %label with ID: %id associated with Salesforce Object ID: %sfid',
-                array(
-                  '%label' => $entity_wrapper->label(),
-                  '%id' => $mapping_object->entity_id,
-                  '%sfid' => $record->id,
-                )
-              );
-            }
+        // Load the mapping that manages these mapped objects.
+        $sf_mapping = reset(salesforce_mapping_load_multiple(
+          array(
+            'salesforce_object_type' => $type,
+            'drupal_entity_type' => $entity_wrapper->type(),
+            'drupal_bundle' => $entity_wrapper->getBundle(),
+          )
+        ));
+
+        // Only delete the mapped Drupal entity if the
+        // SALESFORCE_MAPPING_SYNC_SF_DELETE flag is set.
+        if (!empty($sf_mapping) && ($sf_mapping->sync_triggers & SALESFORCE_MAPPING_SYNC_SF_DELETE)) {
+          // Prevent processing by salesforce_push. We hate circular logic.
+          $entity->salesforce_pull = TRUE;
+
+          // Delete the mapped Drupal entity. Catch any exceptions as
+          // we want to ensure the mapping object is deleted even in
+          // case of an error.
+          try {
+            $entity_wrapper->delete();
+          }
+          catch (Exception $e) {
+            watchdog_exception('salesforce_pull', $e);
           }
 
-
-          // Delete mapping object.
-          $mapping_object->delete();
+          watchdog('Salesforce Pull',
+            'Deleted entity %label with ID: %id associated with Salesforce Object ID: %sfid',
+            array(
+              '%label' => $entity_wrapper->label(),
+              '%id' => $mapping_object->entity_id,
+              '%sfid' => $record->id,
+            )
+          );
         }
       }
+
+      // Delete mapping object.
+      $mapping_object->delete();
     }
-    variable_set('salesforce_pull_delete_last_' . $type, REQUEST_TIME);
   }
 }
 

--- a/modules/salesforce_pull/salesforce_pull.module
+++ b/modules/salesforce_pull/salesforce_pull.module
@@ -613,48 +613,56 @@ function salesforce_pull_process_deleted_records() {
  *   sObject of the Salesforce record.
  */
 function salesforce_pull_map_fields($field_maps, &$entity_wrapper, $sf_object) {
-  foreach ($field_maps as $field_map) {
-    if ($field_map['direction'] == 'sync' || $field_map['direction'] == 'sf_drupal') {
+  $types = salesforce_mapping_get_fieldmap_types();
 
-      $drupal_fields_array = explode(':', $field_map['drupal_field']['fieldmap_value']);
-      $parent = $entity_wrapper;
-      foreach ($drupal_fields_array as $drupal_field) {
-        if ($parent instanceof EntityListWrapper) {
-          $child_wrapper = $parent->get(0)->{$drupal_field};
+  foreach ($field_maps as $field_map) {
+
+    $fieldmap_type = $field_map['drupal_field']['fieldmap_type'];
+    if (!isset($types[$fieldmap_type]['pull_value_callback'])
+      || !in_array($field_map['direction'], array('sync', 'sf_drupal'))
+      || !function_exists($types[$fieldmap_type]['pull_value_callback'])
+    ) {
+      continue;
+    }
+
+    $drupal_fields_array = explode(':', $field_map['drupal_field']['fieldmap_value']);
+    $parent = $entity_wrapper;
+    foreach ($drupal_fields_array as $drupal_field) {
+      if ($parent instanceof EntityListWrapper) {
+        $child_wrapper = $parent->get(0)->{$drupal_field};
+      }
+      else {
+        $child_wrapper = $parent->{$drupal_field};
+      }
+      $parent = $child_wrapper;
+    }
+    $fieldmap_type = salesforce_mapping_get_fieldmap_types($field_map['drupal_field']['fieldmap_type']);
+    $value = call_user_func($fieldmap_type['pull_value_callback'], $parent, $sf_object, $field_map);
+
+    // Allow this value to be altered before assigning to the entity.
+    drupal_alter('salesforce_pull_entity_value', $value, $field_map, $sf_object);
+    if (isset($value)) {
+      // @TODO: might wrongly assumes an individual value wouldn't be an
+      // array.
+      try {
+        if ($parent instanceof EntityListWrapper && !is_array($value)) {
+          $parent->offsetSet(0, $value);
         }
         else {
-          $child_wrapper = $parent->{$drupal_field};
+          $parent->set($value);
         }
-        $parent = $child_wrapper;
       }
-      $fieldmap_type = salesforce_mapping_get_fieldmap_types($field_map['drupal_field']['fieldmap_type']);
-      $value = call_user_func($fieldmap_type['pull_value_callback'], $parent, $sf_object, $field_map);
-
-      // Allow this value to be altered before assigning to the entity.
-      drupal_alter('salesforce_pull_entity_value', $value, $field_map, $sf_object);
-      if (isset($value)) {
-        // @TODO: might wrongly assumes an individual value wouldn't be an
-        // array.
-        try {
-          if ($parent instanceof EntityListWrapper && !is_array($value)) {
-            $parent->offsetSet(0, $value);
-          }
-          else {
-            $parent->set($value);
-          }
-        }
-        catch (Exception $e) {
-          $message = t('Exception during pull for @sfobj.@sffield @sfid to @dobj.@dprop @did with value @v: @e', array(
-            '@sfobj' => $sf_object['attributes']['type'],
-            '@sffield' =>  $field_map['salesforce_field']['name'],
-            '@sfid' => $sf_object['Id'],
-            '@dobj' => $entity_wrapper->type(),
-            '@dprop' => $field_map['drupal_field']['fieldmap_value'],
-            '@did' => $entity_wrapper->getIdentifier(),
-            '@v' => $value,
-            '@e' => $e->getMessage()));
-          throw new Exception($message, $e->getCode(), $e);
-        }
+      catch (Exception $e) {
+        $message = t('Exception during pull for @sfobj.@sffield @sfid to @dobj.@dprop @did with value @v: @e', array(
+          '@sfobj' => $sf_object['attributes']['type'],
+          '@sffield' =>  $field_map['salesforce_field']['name'],
+          '@sfid' => $sf_object['Id'],
+          '@dobj' => $entity_wrapper->type(),
+          '@dprop' => $field_map['drupal_field']['fieldmap_value'],
+          '@did' => $entity_wrapper->getIdentifier(),
+          '@v' => $value,
+          '@e' => $e->getMessage()));
+        throw new Exception($message, $e->getCode(), $e);
       }
     }
   }

--- a/modules/salesforce_pull/salesforce_pull.module
+++ b/modules/salesforce_pull/salesforce_pull.module
@@ -340,8 +340,14 @@ function salesforce_pull_process_records($sf_object) {
             // Set fields values on the Drupal entity.
             salesforce_pull_map_fields($sf_mapping->field_mappings, $wrapper, $sf_object);
 
+            // Allow modules to react just prior to entity save.
+            module_invoke_all('salesforce_pull_entity_presave', $wrapper->value(), $sf_object, $sf_mapping);
+
             // Update entity.
             $wrapper->save();
+
+            // Allow modules to react to entity update.
+            module_invoke_all('salesforce_pull_entity_update', $wrapper->value(), $sf_object, $sf_mapping);
 
             // Update mapping object.
             $mapping_object->last_sync_message = t('Retrieved updates from Salesforce');
@@ -411,7 +417,15 @@ function salesforce_pull_process_records($sf_object) {
         $wrapper = entity_metadata_wrapper($sf_mapping->drupal_entity_type, $entity);
 
         salesforce_pull_map_fields($sf_mapping->field_mappings, $wrapper, $sf_object);
+
+        // Allow modules to react just prior to entity save.
+        module_invoke_all('salesforce_pull_entity_presave', $wrapper->value(), $sf_object, $sf_mapping);
+
         $wrapper->save();
+
+        // Allow modules to react to entity creation.
+        module_invoke_all('salesforce_pull_entity_insert', $wrapper->value(), $sf_object, $sf_mapping);
+
         // Update mapping object.
         $last_sync_message = t('Retrieved new record from Salesforce');
         $last_sync_status = SALESFORCE_MAPPING_STATUS_SUCCESS;

--- a/modules/salesforce_pull/salesforce_pull.module
+++ b/modules/salesforce_pull/salesforce_pull.module
@@ -367,9 +367,10 @@ function salesforce_pull_process_records($sf_object) {
           }
         }
       } catch (Exception $e) {
-        $message = t('Failed to update entity %label from Salesforce object %sfobjectid. Error: @msg',
+        $message = t('Failed to update entity %label %id from Salesforce object %sfobjectid. Error: @msg',
           array(
-            '%label' => $wrapper->label(),
+            '%label' => $mapping_object->entity_type,
+            '%id' => $mapping_object->entity_id,
             '%sfobjectid' => $sf_object['Id'],
             '@msg' => $e->getMessage(),
           )

--- a/modules/salesforce_pull/salesforce_pull.module
+++ b/modules/salesforce_pull/salesforce_pull.module
@@ -308,6 +308,8 @@ function salesforce_pull_process_records($sf_object) {
 
   $sf_mappings = salesforce_mapping_load_multiple($mapping_conditions);
 
+  $hold_exceptions = count($sf_mappings) > 1;
+  $exception = FALSE;
   foreach ($sf_mappings as $sf_mapping) {
     // Mapping object exists?
     $mapping_object = salesforce_mapping_object_load_by_sfid($sf_object['Id']);
@@ -377,6 +379,16 @@ function salesforce_pull_process_records($sf_object) {
         $mapping_object->last_sync_status = SALESFORCE_MAPPING_STATUS_ERROR;
         $mapping_object->last_sync_message = t('Processing failed');
         $mapping_object->last_sync = time();
+        if (!$hold_exceptions) {
+          throw $e;
+        }
+        if (empty($exception)) {
+          $exception = $e;
+        }
+        else {
+          $my_class = get_class($e);
+          $exception = new $my_class($e->getMessage(), $e->getCode(), $exception);
+        }
       }
     }
     else {
@@ -444,6 +456,16 @@ function salesforce_pull_process_records($sf_object) {
         $last_sync_status = SALESFORCE_MAPPING_STATUS_ERROR;
         $last_sync_message = t('Processing failed for new record');
         $entity_updated = NULL;
+        if (!$hold_exceptions) {
+          throw $e;
+        }
+        if (empty($exception)) {
+          $exception = $e;
+        }
+        else {
+          $my_class = get_class($e);
+          $exception = new $my_class($e->getMessage(), $e->getCode(), $exception);
+        }
       }
 
       // If no id exists, the insert failed and we cannot create a mapping
@@ -480,6 +502,9 @@ function salesforce_pull_process_records($sf_object) {
       $mapping_object->last_sync_action = 'pull';
       $mapping_object->save();
     }
+  }
+  if (!empty($exception)) {
+    throw $exception;
   }
 }
 

--- a/modules/salesforce_pull/salesforce_pull.module
+++ b/modules/salesforce_pull/salesforce_pull.module
@@ -30,7 +30,7 @@ function salesforce_pull_menu() {
  * Access callback for Salesforce webhooks.
  */
 function salesforce_pull_webhook_access() {
-  if (variable_get('salesforce_pull_webhook_enable') && $_GET['key'] === variable_get('salesforce_pull_webhook_key')) {
+  if (variable_get('salesforce_pull_webhook_enable') && isset($_GET['key']) && $_GET['key'] === variable_get('salesforce_pull_webhook_key')) {
     return user_access('access content');
   }
 

--- a/modules/salesforce_pull/salesforce_pull.module
+++ b/modules/salesforce_pull/salesforce_pull.module
@@ -311,6 +311,8 @@ function salesforce_pull_process_records($sf_object) {
   foreach ($sf_mappings as $sf_mapping) {
     // Mapping object exists?
     $mapping_object = salesforce_mapping_object_load_by_sfid($sf_object['Id']);
+    // Allow other modules to define or alter the mapping object.
+    drupal_alter('salesforce_pull_mapping_object', $mapping_object, $sf_object, $sf_mapping);
     $exists = $mapping_object ? TRUE : FALSE;
     if ($exists && ($sf_mapping->sync_triggers & SALESFORCE_MAPPING_SYNC_SF_UPDATE)) {
       try {

--- a/modules/salesforce_pull/salesforce_pull.module
+++ b/modules/salesforce_pull/salesforce_pull.module
@@ -245,7 +245,7 @@ function salesforce_pull_get_updated_records() {
     // Convert field mappings to SOQL.
     $soql->fields = array_merge($mapped_fields, array(
       'Id' => 'Id',
-      'LastModifiedDate' => 'LastModifiedDate'
+      $mapping->pull_trigger_date => $mapping->pull_trigger_date
     ));
 
     // If no lastupdate, get all records, else get records since last pull.
@@ -337,7 +337,7 @@ function salesforce_pull_process_records($sf_object) {
           $entity->salesforce_pull = TRUE;
           $entity_updated = isset($entity->updated) ? $entity->updated : $mapping_object->entity_updated;
 
-          $sf_object_updated = strtotime($sf_object['LastModifiedDate']);
+          $sf_object_updated = strtotime($sf_object[$sf_mapping->pull_trigger_date]);
           if ($sf_object_updated > $entity_updated) {
             $wrapper = entity_metadata_wrapper($sf_mapping->drupal_entity_type, $entity);
 

--- a/modules/salesforce_pull/salesforce_pull.module
+++ b/modules/salesforce_pull/salesforce_pull.module
@@ -385,6 +385,13 @@ function salesforce_pull_process_records($sf_object) {
           !empty($entity_info['entity keys']['bundle'])
         ) {
           $values[$entity_info['entity keys']['bundle']] = $sf_mapping->drupal_bundle;
+
+          // Because creating term via entities actually needs vid and won't be
+          // fixed in Entity API (https://www.drupal.org/node/1409256).
+          if (isset($values['vocabulary_machine_name'])) {
+            $vocabulary = taxonomy_vocabulary_machine_name_load($values['vocabulary_machine_name']);
+            $values['vid'] = $vocabulary->vid;
+          }
         }
         else {
           // Not all entities will have bundle defined under entity keys,

--- a/modules/salesforce_push/salesforce_push.module
+++ b/modules/salesforce_push/salesforce_push.module
@@ -120,6 +120,8 @@ function salesforce_push_sync_rest($entity_type, $entity, $mapping, $sf_sync_tri
 
   list($entity_id) = entity_extract_ids($entity_type, $entity);
   $mapping_object = salesforce_mapping_object_load_by_drupal($entity_type, $entity_id, TRUE);
+  // Allow other modules to define or alter the mapping object.
+  drupal_alter('salesforce_push_mapping_object', $mapping_object, $entity, $mapping);
 
   // Delete SF object.
   if ($sf_sync_trigger == SALESFORCE_MAPPING_SYNC_DRUPAL_DELETE) {
@@ -304,13 +306,15 @@ function salesforce_push_cron() {
     // Add entity id to array of pushed entities to check for duplicates later.
     $entity_ids[$item->data['entity_type']][] = $entity_id;
 
-    $mapping_object = salesforce_mapping_object_load_by_drupal($entity_type, $entity_id);
-
     if (!$use_soap) {
       salesforce_push_sync_rest($entity_type, $entity, $mapping, $item->data['trigger']);
       $queue->deleteItem($item);
       continue;
     }
+    
+    $mapping_object = salesforce_mapping_object_load_by_drupal($entity_type, $entity_id);
+    // Allow other modules to define or alter the mapping object.
+    drupal_alter('salesforce_push_mapping_object', $mapping_object, $entity, $mapping);
 
     if ($item->data['trigger'] == SALESFORCE_MAPPING_SYNC_DRUPAL_DELETE && $mapping_object) {
       $delete_list[$delta] = $mapping_object->salesforce_id;

--- a/modules/salesforce_push/salesforce_push.module
+++ b/modules/salesforce_push/salesforce_push.module
@@ -317,6 +317,7 @@ function salesforce_push_cron() {
       continue;
     }
     $wrapper = entity_metadata_wrapper($item->data['entity_type'], $entity);
+    $key_field = $key_value = NULL;
     $params = salesforce_push_map_params($mapping, $wrapper, $key_field, $key_value, $use_soap, !$mapping_object);
 
     $synced_entities[$delta] = array(

--- a/modules/salesforce_push/salesforce_push.module
+++ b/modules/salesforce_push/salesforce_push.module
@@ -308,6 +308,7 @@ function salesforce_push_cron() {
 
     if (!$use_soap) {
       salesforce_push_sync_rest($entity_type, $entity, $mapping, $item->data['trigger']);
+      $queue->deleteItem($item);
       continue;
     }
 

--- a/modules/salesforce_push/salesforce_push.module
+++ b/modules/salesforce_push/salesforce_push.module
@@ -119,32 +119,44 @@ function salesforce_push_sync_rest($entity_type, $entity, $mapping, $sf_sync_tri
   }
 
   list($entity_id) = entity_extract_ids($entity_type, $entity);
+  $entity_wrapper = entity_metadata_wrapper($entity_type, $entity);
+
   $mapping_object = salesforce_mapping_object_load_by_drupal($entity_type, $entity_id, TRUE);
   // Allow other modules to define or alter the mapping object.
   drupal_alter('salesforce_push_mapping_object', $mapping_object, $entity, $mapping);
 
+  $synced_entity = array(
+    'entity_wrapper' => $entity_wrapper,
+    'mapping_object' => $mapping_object,
+    'queue_item' => FALSE,
+    'mapping' => $mapping,
+  );
+
+  $op = '';
   // Delete SF object.
   if ($sf_sync_trigger == SALESFORCE_MAPPING_SYNC_DRUPAL_DELETE) {
     if ($mapping_object) {
+      $op = 'Delete';
       try {
         $sfapi->objectDelete($mapping->salesforce_object_type, $mapping_object->salesforce_id);
       }
       catch(SalesforceException $e) {
         watchdog_exception('salesforce_push', $e);
         salesforce_set_message($e->getMessage(), 'error');
+        module_invoke_all('salesforce_push_fail', $op, $sfapi->response, $synced_entity);
       }
 
       salesforce_set_message(t('Salesforce object %sfid has been deleted.', array(
         '%sfid' => $mapping_object->salesforce_id,
       )));
       $mapping_object->delete();
+      module_invoke_all('salesforce_push_success', $op, $sfapi->response, $synced_entity);
     }
     // No mapped object or object was deleted.
     return;
   }
 
   // Generate parameter array from field mappings.
-  $entity_wrapper = entity_metadata_wrapper($entity_type, $entity);
   $params = salesforce_push_map_params($mapping, $entity_wrapper, $key_field, $key_value, FALSE, !$mapping_object);
 
   // Entity is not linked to an SF object.
@@ -166,6 +178,7 @@ function salesforce_push_sync_rest($entity_type, $entity, $mapping, $sf_sync_tri
         // https://developer.salesforce.com/forums?id=906F000000099xPIAQ
         $encoded_value = str_replace('.', '%2E', $encoded_value);
 
+        $op = 'Upsert';
         $data = $sfapi->objectUpsert($mapping->salesforce_object_type, $key_field, $encoded_value, $params);
         // Handle upsert responses.
         switch ($sfapi->response->code) {
@@ -184,12 +197,14 @@ function salesforce_push_sync_rest($entity_type, $entity, $mapping, $sf_sync_tri
       }
       // No key or mapping, create a new object in Salesforce.
       else {
+        $op = 'Create';
         $data = $sfapi->objectCreate($mapping->salesforce_object_type, $params);
       }
     }
     catch(SalesforceException $e) {
       watchdog_exception('salesforce_push', $e);
       salesforce_set_message($e->getMessage(), 'error');
+      module_invoke_all('salesforce_push_fail', $op, $sfapi->response, $synced_entity);
       return;
     }
 
@@ -203,6 +218,7 @@ function salesforce_push_sync_rest($entity_type, $entity, $mapping, $sf_sync_tri
         'last_sync_message' => t('Mapping object created via !function.', array('!function' => __FUNCTION__)),
         'last_sync_status' => SALESFORCE_MAPPING_STATUS_SUCCESS,
       ));
+      module_invoke_all('salesforce_push_success', $op, $sfapi->response, $synced_entity);
     }
     else {
       $message = t('Failed to sync %label with Salesforce. @code: @message',
@@ -214,6 +230,7 @@ function salesforce_push_sync_rest($entity_type, $entity, $mapping, $sf_sync_tri
       );
       salesforce_set_message($message, 'error');
       watchdog('salesforce_push', $message);
+      module_invoke_all('salesforce_push_fail', $op, $sfapi->response, $synced_entity);
       return;
     }
   }
@@ -227,6 +244,7 @@ function salesforce_push_sync_rest($entity_type, $entity, $mapping, $sf_sync_tri
 
     // Update SF object.
     try {
+      $op = 'Update';
       $sfapi->objectUpdate($mapping->salesforce_object_type, $mapping_object->salesforce_id, $params);
       $mapping_object->last_sync_message = t('Mapping object updated via !function.', array('!function' => __FUNCTION__));
       $mapping_object->last_sync_status = SALESFORCE_MAPPING_STATUS_SUCCESS;
@@ -235,6 +253,7 @@ function salesforce_push_sync_rest($entity_type, $entity, $mapping, $sf_sync_tri
         '%name' => $entity_wrapper->label(),
         '%sfid' => $mapping_object->salesforce_id,
       )));
+      module_invoke_all('salesforce_push_success', $op, $sfapi->response, $synced_entity);
     }
     catch(SalesforceException $e) {
       watchdog_exception('salesforce_push', $e);
@@ -246,6 +265,7 @@ function salesforce_push_sync_rest($entity_type, $entity, $mapping, $sf_sync_tri
       )), 'error');
       $mapping_object->last_sync_message = $e->getMessage();
       $mapping_object->last_sync_status = SALESFORCE_MAPPING_STATUS_ERROR;
+      module_invoke_all('salesforce_push_fail', $op, $sfapi->response, $synced_entity);
     }
   }
 
@@ -328,6 +348,7 @@ function salesforce_push_cron() {
       'entity_wrapper' => $wrapper,
       'mapping_object' => $mapping_object,
       'queue_item' => $item,
+      'mapping' => $mapping,
     );
 
     // Setup SF record type. CampaignMember objects get their type from

--- a/modules/salesforce_push/salesforce_push.module
+++ b/modules/salesforce_push/salesforce_push.module
@@ -149,7 +149,7 @@ function salesforce_push_sync_rest($entity_type, $entity, $mapping, $sf_sync_tri
   if (!$mapping_object) {
     // Setup SF record type. CampaignMember objects get their Campaign's type.
     if ($mapping->salesforce_record_type_default != SALESFORCE_MAPPING_DEFAULT_RECORD_TYPE
-      && empty($params['RecordTypeId'])
+      && !array_key_exists('RecordTypeId', $params)
       && ($mapping->salesforce_object_type != 'CampaignMember')) {
       $params['RecordTypeId'] = $mapping->salesforce_record_type_default;
     }

--- a/modules/salesforce_soap/salesforce_soap.install
+++ b/modules/salesforce_soap/salesforce_soap.install
@@ -13,7 +13,15 @@ function salesforce_soap_requirements($phase) {
   // Ensure translations don't break at install time.
   $t = get_t();
 
-  if ($phase == 'runtime' && !libraries_get_path('salesforce')) {
+  if ($phase == 'runtime') {
+    $library = libraries_detect('salesforce');
+    $library_available = !empty($library['installed']);
+  }
+  else if ($phase == 'install') {
+    $library_available = libraries_get_path('salesforce');
+  }
+
+  if (!$library_available) {
     $requirements['salesforce'] = array(
       'title' => $t('Salesforce PHP Toolkit'),
       'description' => $t(

--- a/modules/salesforce_soap/salesforce_soap.module
+++ b/modules/salesforce_soap/salesforce_soap.module
@@ -9,6 +9,32 @@
  * Implements hook_init().
  */
 function salesforce_soap_init() {
-  $path = libraries_get_path('salesforce');
-  require_once $path . '/soapclient/SforcePartnerClient.php';
+  libraries_load('salesforce');
+}
+
+/**
+ * Implements hook_libraries_info
+ */
+function salesforce_soap_libraries_info() {
+  return array(
+    'salesforce' => array(
+      'name' => 'salesforce',
+      'version callback' => 'salesforce_soap_libraries_version_callback',
+      'path' => 'soapclient',
+      'vendor url' => 'https://github.com/developerforce/Force.com-Toolkit-for-PHP/',
+      'download url' => 'https://github.com/developerforce/Force.com-Toolkit-for-PHP/archive/master.zip',
+      'files' => array(
+        'php' => array(
+          'SforcePartnerClient.php',
+        ),
+      ),
+    ),
+  );
+}
+
+/**
+ * Dummy version callback for hook_libraries_info
+ */
+function salesforce_soap_libraries_version_callback() {
+  return TRUE;
 }

--- a/salesforce.api.php
+++ b/salesforce.api.php
@@ -38,13 +38,13 @@ function hook_salesforce_mapping_fieldmap_type_alter($fieldmap_type) {
  *   if no exisitng mapping object exists.
  * @param array $sf_object
  *   The salesforce object data that will be used in this pull.
- * @param object $mapping
+ * @param SalesforceMapping $mapping
  *   The salesforce mapping that will be used during the pull.
  */
 function hook_salesforce_pull_mapping_object_alter(&$mapping_object, $sf_object, $mapping) {
   // Do some prematching for incoming user pulls if we don't already have a
   // match.
-  if (!$mapping_object && $sf_mapping->drupal_entity_type == 'user') {
+  if (!$mapping_object && $mapping->drupal_entity_type == 'user') {
     // Run some complex custom prematching logic that searches for an existing
     // Drupal user that is a match to the incoming Salesforce data.
     $matched_user = mymodule_custom_sf_pull_prematch($sf_object, $mapping);
@@ -54,8 +54,8 @@ function hook_salesforce_pull_mapping_object_alter(&$mapping_object, $sf_object,
       // user instead of creating a new one.
       entity_create('salesforce_mapping_object', array(
         'salesforce_id' => $sf_object['Id'],
-        'entity_type' => $sf_mapping->drupal_entity_type,
-        'entity_id' => $match->uid,
+        'entity_type' => $mapping->drupal_entity_type,
+        'entity_id' => $matched_user->uid,
         'last_sync_message' => t('User prematch on pull'),
         'last_sync_status' => SALESFORCE_MAPPING_STATUS_SUCCESS
       ))->save();
@@ -72,13 +72,13 @@ function hook_salesforce_pull_mapping_object_alter(&$mapping_object, $sf_object,
  *   if no exisitng mapping object exists.
  * @param object $entity
  *   The Drupal entity that is being pushed.
- * @param object $mapping
+ * @param SalesforceMapping $mapping
  *   The salesforce mapping that will be used during the push.
  */
 function hook_salesforce_push_mapping_object_alter(&$mapping_object, $entity, $mapping) {
   // Do some prematching for outgoing user pushes if we don't already have a
   // match.
-  if (!$mapping_object && $sf_mapping->drupal_entity_type == 'user') {
+  if (!$mapping_object && $mapping->drupal_entity_type == 'user') {
     // Run some complex custom prematching logic that queries Salesforce for an
     // existing contact (beyond a basic external key comparison) that is a match
     // to this Drupal user.
@@ -88,9 +88,9 @@ function hook_salesforce_push_mapping_object_alter(&$mapping_object, $entity, $m
       // This means that the rest of the push logic will target this matched
       // contact instead of creating a new one.
       entity_create('salesforce_mapping_object', array(
-        'salesforce_id' => $sf_object['Id'],
-        'entity_type' => $sf_mapping->drupal_entity_type,
-        'entity_id' => $match->uid,
+        'salesforce_id' => $matched_contact['Id'],
+        'entity_type' => $mapping->drupal_entity_type,
+        'entity_id' => $entity->uid,
         'last_sync_message' => t('User prematch on push'),
         'last_sync_status' => SALESFORCE_MAPPING_STATUS_SUCCESS
       ))->save();

--- a/salesforce.api.php
+++ b/salesforce.api.php
@@ -202,11 +202,13 @@ function hook_salesforce_query_alter(SalesforceSelectQuery &$query) {
  * @param object $result
  *   The salesforce response
  * @param array $synced_entity
- *   Entity data for this push. This array has 3 keys
+ *   Entity data for this push. This array has 4 keys
  *     'entity_wrapper': entity_metadata_wrapper() for the Drupal entity 
  *     'mapping_object': salesforce mapping object record, if it exists. 
  *       Otherwise null
- *     'queue_item': Drupal queue item corresponding to this push attempt
+ *     'queue_item': If this is a SOAP push, Drupal queue item corresponding to
+ *       this push attempt. Otherwise FALSE.
+ *     'mapping': SalesforceMapping being used for this push
  */
 function hook_salesforce_push_success($op, $result, $synced_entity) {
   $mapping_object = FALSE;
@@ -252,11 +254,13 @@ function hook_salesforce_push_success($op, $result, $synced_entity) {
  * @param object $result
  *   The salesforce response
  * @param array $synced_entity
- *   Entity data for this push. This array has 3 keys
+ *   Entity data for this push. This array has 4 keys
  *     'entity_wrapper': entity_metadata_wrapper() for the Drupal entity 
  *     'mapping_object': salesforce mapping object record, if it exists. 
  *       Otherwise null
- *     'queue_item': Drupal queue item corresponding to this push attempt
+ *     'queue_item': If this is a SOAP push, Drupal queue item corresponding to
+ *       this push attempt. Otherwise FALSE.
+ *     'mapping': SalesforceMapping being used for this push
  */
 function hook_salesforce_push_fail($op, $result, $synced_entity) {
   $error_messages = array();

--- a/salesforce.api.php
+++ b/salesforce.api.php
@@ -236,7 +236,7 @@ function hook_salesforce_push_fail($op, $result, $synced_entity) {
  *   The Drupal entity object.
  * @param array $sf_object
  *   The Salesforce query result array.
- * @param SalesforceMapping $sf_object
+ * @param SalesforceMapping $sf_mapping
  *   The Salesforce Mapping being used to pull this record
  *
  * @throws SalesforcePullException
@@ -258,7 +258,7 @@ function hook_salesforce_pull_entity_presave($entity, $sf_object, $sf_mapping) {
  *   The Drupal entity object.
  * @param array $sf_object
  *   The SObject from the pull query (as an array).
- * @param SalesforceMapping $sf_object
+ * @param SalesforceMapping $sf_mapping
  *   The Salesforce Mapping being used to pull this record
  *
  * @throws SalesforcePullException
@@ -289,7 +289,7 @@ function hook_salesforce_pull_entity_insert($entity, $sf_object, $sf_mapping) {
  *   The Drupal entity object.
  * @param array $sf_object
  *   The SObject from the pull query (as an array).
- * @param SalesforceMapping $sf_object
+ * @param SalesforceMapping $sf_mapping
  *   The Salesforce Mapping being used to pull this record
  *
  * @throws SalesforcePullException

--- a/salesforce.drush.inc
+++ b/salesforce.drush.inc
@@ -81,6 +81,13 @@ function salesforce_drush_command() {
     'description' => 'Lists the resources available for the specified API version. It provides the name and URI of each resource.',
     'aliases' => array('sflr'),
   );
+  $items['sf-execute-query'] = array(
+    'description' => 'Execute a SOQL query.',
+    'aliases' => array('sfeq'),
+    'arguments' => array(
+      'query' => 'The query to execute.',
+    ),
+  );
   return $items;
 }
 
@@ -331,6 +338,26 @@ function drush_salesforce_sf_query_object($name) {
     $query = 'SELECT ' . $fields . ' FROM ' . $name;
     // @todo - figure how to leverage SalesforceSelectQuery.
     $result = $salesforce->apiCall('query?q=' . urlencode($query . $where));
+    drush_print(drush_format($result));
+  }
+  catch (SalesforceException $e) {
+    drush_log($e->getMessage(), 'error');
+  }
+}
+
+/**
+ * Execute a SOQL query.
+ *
+ * @param $query
+ *   The query to execute
+ */
+function drush_salesforce_sf_execute_query($query = NULL) {
+  if (!$query) {
+    return drush_log('Please specify a query as an argument.', 'error');
+  }
+  $salesforce = _drush_salesforce_drush_get_api();
+  try {
+    $result = $salesforce->apiCall('query?q=' . urlencode($query));
     drush_print(drush_format($result));
   }
   catch (SalesforceException $e) {

--- a/salesforce.install
+++ b/salesforce.install
@@ -38,3 +38,18 @@ function salesforce_update_7300() {
     db_create_table($schema_name, $schema[$schema_name]);
   }
 }
+
+/**
+ * Update API version to 29.0 for getUpdated() support.
+ */
+function salesforce_update_7301() {
+  $version = variable_get('salesforce_api_version', array());
+  if (empty($version) || version_compare($version['version'], "29.0") < 0) {
+    variable_set('salesforce_api_version', array(
+      "label" => "Winter '14",
+      "url" => "/services/data/v29.0/",
+      "version" => "29.0",
+    ));
+  }
+}
+

--- a/salesforce.module
+++ b/salesforce.module
@@ -168,6 +168,16 @@ function salesforce_oauth_form() {
   $consumer_secret = variable_get('salesforce_consumer_secret', FALSE);
   $salesforce_endpoint = variable_get('salesforce_endpoint', 'https://login.salesforce.com');
 
+  if (module_exists('encrypt')) {
+    // Add try catch in case data was not yet encrypted.
+    try {
+      $consumer_key = decrypt($consumer_key);
+      $consumer_secret = decrypt($consumer_secret);
+    }
+    catch (Exception $e) {
+    }
+  }
+
   $form['message'] = array(
     '#type' => 'item',
     '#markup' => t('Authorize this website to communicate with Salesforce by entering the consumer key and secret from a remote application. Clicking authorize will redirect you to Salesforce where you will be asked to grant access.'),
@@ -206,7 +216,7 @@ function salesforce_oauth_form() {
 
   // If we're authenticated, show a list of available REST resources.
   if ($consumer_key && $consumer_secret) {
-    $sfapi = new Salesforce($consumer_key, $consumer_secret);
+    $sfapi = salesforce_get_api();
     // If fully configured, attempt to connect to Salesforce and return a list
     // of resources.
     if ($sfapi->isAuthorized()) {
@@ -245,11 +255,15 @@ function salesforce_oauth_form_submit($form, &$form_state) {
   $consumer_key = $form_state['values']['salesforce_consumer_key'];
   $consumer_secret = $form_state['values']['salesforce_consumer_secret'];
   $salesforce_endpoint = $form_state['values']['salesforce_endpoint'];
+  if (module_exists('encrypt')) {
+    $consumer_key = encrypt($consumer_key);
+    $consumer_secret = encrypt($consumer_secret);
+  }
   variable_set('salesforce_consumer_key', $consumer_key);
   variable_set('salesforce_consumer_secret', $consumer_secret);
   variable_set('salesforce_endpoint', $salesforce_endpoint);
 
-  $salesforce = new Salesforce($consumer_key, $consumer_secret);
+  $salesforce = salesforce_get_api();
   $salesforce->getAuthorizationCode();
 }
 
@@ -344,9 +358,17 @@ function salesforce_oauth_callback() {
  *   Returns a Salesforce class object.
  */
 function salesforce_get_api() {
+  $consumer_key = variable_get('salesforce_consumer_key', '');
+  $consumer_secret = variable_get('salesforce_consumer_secret', '');
+
+  if (module_exists('encrypt')) {
+    $consumer_key = decrypt($consumer_key);
+    $consumer_secret = decrypt($consumer_secret);
+  }
+
   return new Salesforce(
-    variable_get('salesforce_consumer_key', ''),
-    variable_get('salesforce_consumer_secret', '')
+    $consumer_key,
+    $consumer_secret
   );
 }
 

--- a/salesforce.module
+++ b/salesforce.module
@@ -15,7 +15,7 @@ function salesforce_help($path, $arg) {
     case 'admin/structure/salesforce':
       $output = '';
       if (!module_exists('salesforce_mapping')) {
-        $output .= '<p>' . t('In order to configure Salesforce Mappings, you must first enable the <a href="/admin/modules">Salesforce Mapping</a> module.') . '</p>';
+        $output .= '<p>' . t('In order to configure Salesforce Mappings, you must first enable the <a href="/admin/modules">Salesforce Mapping</a> module and at least one sync method (Push or Pull).') . '</p>';
       }
       if (!variable_get('salesforce_consumer_secret', NULL) || !variable_get('salesforce_consumer_key', NULL) || !variable_get('salesforce_refresh_token', NULL)) {
         $output .= '<p>' . t('You must !authorize in order to configure Salesforce Mappings.', array('!authorize' => l(t('authorize your account with Salesforce'), 'admin/config/salesforce/authorize'))) . '</p>';

--- a/tests/salesforce.test
+++ b/tests/salesforce.test
@@ -58,6 +58,7 @@ class SalesforceTestCase extends DrupalWebTestCase {
     $salesforce_vars = array(
       'salesforce_consumer_key',
       'salesforce_consumer_secret',
+      'salesforce_endpoint',
       'salesforce_instance_url',
       'salesforce_refresh_token',
       'salesforce_identity',


### PR DESCRIPTION
This PR represents the additional work I've done over the last few days prepping for a 7.1-3.2 release of Salesforce. Any commits previous to July 15th are non-synced Drupal commits. Any items from the 15th on are either my cleanup or merging in of "Needs Review" patches I deemed worthy.

If you see any red flags, please let me know!

Here are the Release Notes I'm planning on attaching to the release:

---

Major additions in this release:

---

New admin page

The /admin/config/salesforce/settings page where you can configure which version of the API you're using. You can also configure pulls via a webhook instead of cron. 

Additionally, the mappings pages have been cleaned up by Issue #1980688: Push/pull UI improvements. This removes the temptation to try to sync or push an item if, say, you only have the Salesforce Pull module enabled. 

---

New hooks

Issue #1909990: hook_salesforce_push_entity_allowed, hook_salesforce_push_success, hook_salesforce_push_fail for filtering entities before push, and for reacting to push successes and failures.

Issue #2745063: hook_salesforce_pull_mapping_object_alter and hook_salesforce_push_mapping_object_alter for manipulating mapping_object objects Immediately before pull or push

Issue #2688033: hook_salesforce_pull_entity_presave, hook_salesforce_pull_entity_insert, and hook_salesforce_pull_entity_update, which mimic the default hook_entity_XX, but also expose the original Salesforce Mapping values for consideration.

Side note here: If you are using a dev version of the Salesforce module and taking advantage of hook_salesforce_push_entity_allowed_by_mapping, that function will no longer work, as it's been rolled into hook_salesforce_push_entity_allowed.

---

New functionality

You can now do pulls from Salesforce via a webhook instead of cron by visiting /salesforce/webhook/pull and including a token. Option can be set up here: /admin/config/salesforce/settings

You can also now delete without using the SOAP module. Note: This requires you to be on a version of the Salesforce API of  29.0 (Winter '14) or greater. This setting can be checked here: /admin/config/salesforce/settings. See Issue #2730357 for more.

If you're using SOAP, you can overwrite the default WSDL by setting the variable "salesforce_partner_wsdl" to a given path. Currently there's no UI for this, but the variable can be set using Drush or as a $conf variable in your settings.php file.

---

New drush command

Drush command "sf-execute-query" to directly query Salesforce. See Issue #2637508.

---

All commits included in this release:
## Salesforce API pending-7.1-3.2, 2016-07-19
- Adding comment.
- URI validation fails on salesforce pull mapping "website" to "link".
- Salesforce_soap_requirements() cannot access libraries_get_path().
- Improved testing comment.
- Should SF pull process use "pull_trigger_date" instead of "LastModifiedDate"?.
- Add push success/failure hooks for REST.
- Errors during salesforce_pull_map_fields().
- Exception during exception handling.
- Bubble exceptions during cron pull.
- More helpful error messaging in salesforce_pull_map_fields().
- Running tests through coder and adding unit test for salesforce_mapping_load_multiple.
- .
- 2488000: Small documentation error.
- Github Issue #100: Avoid undefined index warnings if no  is set.
- Add missing parameter to documentation.
- .
- Cleaning up api parameters.
- Small fixes to API documentation examples.
- _uri() functions error after menu cache clear.
- Add alter hooks to manipulate mapping objects on pull and push (for custom prematching, etc.).
- Sync deletions on pull without using SOAP client.
- Add entity_presave/insert/update sf pull hooks.
- Drush command to execute a SOQL query.
- Queries with spaces not translated.
- Allow 'salesforce_endpoint' values in test environment.
- Strict warning: Only variables should be passed by reference in salesforce_mapping_form_submit.
- Allow for null RecordTypeId.
- Cannot access Salesforce REST API through Squid proxy.
- Salesforce::apiCall() has PHP version dependency.
- Better UI when only one mapping direction enabled.
- RTBC - Taxonomy Terms pulling without vid.
- Store Salesforce Object Type Name in salesforce_mapping_object table.
- Add "getUpdated()" wrapper to Salesforce class; Update default salesforce api version to Winter '14.
- Upserting any item during batch processing cron attempts to upsert all subsequent records.
- Async option cron run fails to remove push items from queue unless salesforce_soap is enabled.
- Handle allowed record types configuration set by features.
- Merge branch '7.x-3.x' of github.com:thinkshout/salesforce into 7.x-3.x.
- Merge pull request #100 from thinkshout/webhooks.
- Standardize on the REQUEST_TIME constant.
- Process salesforce_pull queue items as part of webhook request.
- Refactor webhook and cron pull actions into a single function.
- Broader code style updates.
- Add actual webhook url to the field help text.
- Move webhook related code into salesforce_pull until/if we have non-pull webhooks.
- Swapped out undefined method Salesforce::verifyId for convertId.
- Add throttle to salesforce pull - prevent too many from running at once.
- Add a webhook callback for salesforce pull.
- Use same level of permission as oauth_callback. Add example for key.
- Webhook settings and access.
- Updates pushing to non-updateable fields causes errors.
- Add OFFSET clause to SalesforceSelectQuery.
- Fix import to integer property (allow mapping SF checkbox to Node status).
- Add documentation for hook_salesforce_query_alter().
- Combine hook_salesforce_push_entity_allowed_by_mapping into hook_salesforce_push_entity_allowed with the additional $mapping argument.
- Fix references to $synced_entity, and refactor $mapping_object reference.
- Undefined variable.
- Switch sort method, so the list is sorted in a more expected way.
- Display field key alongside the field name, to disambiguate fields with the same name.
- Update pull value callback for relation endpoint fieldmap type (i.e. salesforce_mapping_relation_endpoints_fieldmap_pull_value) to ensure directional endpoints only get returned if they match the allowed source and target bundles, respectively. Previously we were appending our return values for directional relations to the same array we used to aggregate the values in the first place, which could result in the first value of the return array being a duplicate of the second if there was only one endpoint present and it was the target endpoint in a directional relation.
- Add a configurable "update field" for mappings.
- SalesForce views module not working for users.
- Cast to bool when pushing to a boolean SF field.
- Make REST API version configurable.
- Add support for apexrest URLs.
- Removing debugging cruft.
- Notice created via salesforce_mapping_menu().
- Merge branch '7.x-3.x' of git.drupal.org:project/salesforce into 7.x-3.x.
- Fixing synxtax error from commit 4acc573.
- Fixing hook_menu for users in sf mapping. Anonymous user with id = 0 is breaking things.
- Add "push" button to mapping object edit form to force update from drupal.
- Adding "convertId" function to translate between 15 and 18 char SFIDs.
- Mappings with LastModifiedDate field fail due to being included twice in SalesforceSelectQuery.
- Change entity_id and entity_type to values in salesforce_mapping_object_form.
- Changing "mapped_object" to "mapping_object".
- Conditional Push to Salesforce; Adding hooks: hook_salesforce_push_entity_allowed_by_mapping, hook_salesforce_push_success, hook_salesforce_push_fail.
- Adding hooks: hook_salesforce_push_entity_allowed_by_mapping, hook_salesforce_push_success, hook_salesforce_push_fail.
- Better entity support in salesforce_mapping_menu().
- Improve exception thrown when drupal entity fails to be created from SF object by including the SF object ID so user can more easily track down source of the failure.
- One more mapped/mapping change.
- Renaming confusing variable references to "mapped_objects" which is actually a single "mapping object".
- .
- Removing unnecessary module_load_include() calls.
- Forgot the row id.
- Adding theme_salesforce_mapping_form_table_row() to fix compatibility for any themes which override theme_table(); converted fieldmap form token tree to use jquery ui dialog per #1684984.
- Sort fields alphabetically for ease of use.
- Remove unused extra fields definitions.
- Change STARTS_WITH operator to LIKE with proper escaping.
- Check if variable is set instead of acting directly on it to avoid "undefined index: <sf-object-id> in salesforce_mapping_load_multiple()" error.
